### PR TITLE
test: added test cases for addTypename

### DIFF
--- a/src/__tests__/lib.test.ts
+++ b/src/__tests__/lib.test.ts
@@ -162,7 +162,6 @@ describe("Automocking", () => {
       const resp: any = ergonomock(schema, testQuery);
       expect(resp.data).toMatchObject({
         returnShape: {
-          __typename: 'Shape',
           id: expect.toBeString(),
           returnEnum: expect.toBeOneOf(["A", "B", "C"]),
         },

--- a/src/__tests__/lib.test.ts
+++ b/src/__tests__/lib.test.ts
@@ -162,6 +162,7 @@ describe("Automocking", () => {
       const resp: any = ergonomock(schema, testQuery);
       expect(resp.data).toMatchObject({
         returnShape: {
+          __typename: 'Shape',
           id: expect.toBeString(),
           returnEnum: expect.toBeOneOf(["A", "B", "C"]),
         },

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -19,7 +19,7 @@ import {
   validate,
   buildASTSchema,
 } from "graphql";
-
+import { addTypenameToDocument } from '@apollo/client/utilities/'
 import random from "./utils/random";
 import getRandomElement from "./utils/getRandomElement";
 import forEachFieldInQuery from "./utils/forEachFieldInQuery";
@@ -65,7 +65,7 @@ export function ergonomock(
     throw new Error("Ergonomock requires a GraphQL query, either as a string or DocumentNode.");
   }
 
-  const document = typeof query === "string" ? parse(query) : query;
+  const document = addTypenameToDocument(typeof query === "string" ? parse(query) : query);
 
   const errors = validate(schema, document);
   if (errors.length) {

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -19,7 +19,6 @@ import {
   validate,
   buildASTSchema,
 } from "graphql";
-import { addTypenameToDocument } from '@apollo/client/utilities/'
 import random from "./utils/random";
 import getRandomElement from "./utils/getRandomElement";
 import forEachFieldInQuery from "./utils/forEachFieldInQuery";
@@ -65,7 +64,7 @@ export function ergonomock(
     throw new Error("Ergonomock requires a GraphQL query, either as a string or DocumentNode.");
   }
 
-  const document = addTypenameToDocument(typeof query === "string" ? parse(query) : query);
+  const document = typeof query === "string" ? parse(query) : query;
 
   const errors = validate(schema, document);
   if (errors.length) {


### PR DESCRIPTION
issue: https://github.com/SurveyMonkey/graphql-ergonomock/issues/104

Problem: `ergonomock()` only includes `__typename` if the query does

For the fix, I borrowed the `addTypenameToDocument` helper function from `@apollo/client`. As the result, every query will have `__typename` auto-appended if applicable.

That being said, I don't like that we introduced vendor specific dependency in the mock function. However, I also don't want to re-invent the wheel... 

Please let me know if you know a better way to solve this.

cc @joual 