### PR TITLE
feat: allow users to provider default mock resolvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,56 @@ const mocks = {
 </p></details>
 
 
+#### Providing default mock resolver functions
+
+If you have custom scalar types or would like to provide default mock resolver functions for certain types, you can pass your mock functions via the `resolvers` option.
+
+<details>
+<summary>See example</summary><p>
+
+```js
+const schema = gql`
+  type Shape = {
+    id: ID!
+    returnInt: Int
+    date: Date
+    nestedShape: Shape
+  }
+
+  type Query {
+    getShape: Shape
+  }
+`;
+
+const testQuery = gql`
+{
+  getShape {
+    id
+    returnInt
+    date
+    nestedShape {
+      date
+    }
+  }
+}
+`;
+
+const resp = ergonomock(schema, testQuery, {
+  resolvers: {
+    Date: () => "2021-04-09"
+  }
+});
+expect(resp.data).toMatchObject({
+  id: expect.toBeString(),
+  returnInt: expect.toBeNumber(),
+  date: '2021-04-09'
+  nestedShape {
+    date: '2021-04-09'
+  }
+});
+```
+</p></details>
+
 #### Mocking Errors
 
 You can return or throw errors within the mock shape.
@@ -431,6 +481,7 @@ This component's props are very similar to Apollo-Client's [MockedProvider](http
 
 - `mocks` is an object where keys are the operation names and the values are the `mocks` input that `ergonomock()` would accept. (i.e. could be empty, or any shape that matches the expected response.)
 - `onCall` is a handler that gets called by any executed query. The call signature is `({operation: GraphQLOperation, response: any}) => void` where response is the full response being returned to that single query. The purpose of `onCall` is to provide some sort of spy (or `jest.fn()`) to make assertions on which calls went through, with which variables, and get a handle on the generated values from `ergonomock()`.
+- `resolvers` is an object where the keys are the `gql` type and the values are the mock resolver functions. It's designed to allow users to override or provide a default mock function for certain types. (e.g. custom scalar types) The call signature is `(root, args, context, info) => any`.
 
 <!-- ROADMAP -->
 ## Roadmap

--- a/src/__tests__/schema.ts
+++ b/src/__tests__/schema.ts
@@ -2,6 +2,7 @@ import { buildSchemaFromTypeDefinitions } from "graphql-tools";
 
 const schemaSDL = /* GraphQL */ `
   scalar MissingMockType
+  scalar CustomScalarType
   interface Flying {
     id: ID!
     returnInt: Int
@@ -41,6 +42,7 @@ const schemaSDL = /* GraphQL */ `
     returnIDList: [ID]
     nestedShape: Shape
     nestedShapeList: [Shape]
+    returnCustomScalar: CustomScalarType
   }
   type RootQuery {
     returnInt: Int

--- a/src/apollo/ErgonoMockedProvider.tsx
+++ b/src/apollo/ErgonoMockedProvider.tsx
@@ -1,16 +1,16 @@
 import React from "react";
+import { GraphQLSchema, DocumentNode } from "graphql";
 import {
   ApolloClient,
   DefaultOptions,
   ApolloCache,
-  Resolvers,
   ApolloLink,
   InMemoryCache,
   ApolloProvider,
   NormalizedCacheObject
 } from "@apollo/client";
 import MockLink, { ApolloErgonoMockMap, MockLinkCallHandler } from "./MockLink";
-import { GraphQLSchema, DocumentNode } from "graphql";
+import { DefaultMockResolvers } from '../mock';
 
 export interface ErgonoMockedProviderProps<TSerializedCache = {}> {
   schema: GraphQLSchema | DocumentNode;
@@ -19,7 +19,7 @@ export interface ErgonoMockedProviderProps<TSerializedCache = {}> {
   addTypename?: boolean;
   defaultOptions?: DefaultOptions;
   cache?: ApolloCache<TSerializedCache>;
-  resolvers?: Resolvers;
+  resolvers?: DefaultMockResolvers;
   children?: React.ReactElement;
   link?: ApolloLink;
 }
@@ -40,8 +40,7 @@ export default function ErgonoMockedProvider(props: ErgonoMockedProviderProps) {
     const c = new ApolloClient({
       cache: cache || new InMemoryCache({ addTypename }),
       defaultOptions,
-      link: link || new MockLink(schema, mocks || {}, { addTypename, onCall }),
-      resolvers
+      link: link || new MockLink(schema, mocks || {}, { addTypename, onCall, resolvers }),
     });
     setClient(c);
     return () => client && ((client as unknown) as ApolloClient<any>).stop();

--- a/src/apollo/MockLink.ts
+++ b/src/apollo/MockLink.ts
@@ -1,11 +1,12 @@
 import { ApolloLink, Operation, Observable, FetchResult } from "@apollo/client";
-import { ErgonoMockShape, ergonomock } from "../mock";
+import { ErgonoMockShape, ergonomock, DefaultMockResolvers } from "../mock";
 import { GraphQLSchema, ExecutionResult, DocumentNode } from "graphql";
 import stringify from "fast-json-stable-stringify";
 
 type MockLinkOptions = {
   addTypename: Boolean;
   onCall?: MockLinkCallHandler;
+  resolvers?: DefaultMockResolvers;
 };
 
 export type ApolloErgonoMockMap = Record<
@@ -53,6 +54,7 @@ export default class MockLink extends ApolloLink {
       mocks: mock || {},
       seed,
       variables: operation.variables,
+      resolvers: this.options.resolvers,
     });
 
     // Return Observer to be compatible with apollo


### PR DESCRIPTION
Issue: https://github.com/SurveyMonkey/graphql-ergonomock/issues/104

Allows users to provide default mock resolver.

In the case of custom scalar types, we only need to provide a default mock resolver function at the mock provider level and all the occurrences within the query should automatically using the value provided by the mock resolver.

example test case
```javascript
// setup
render(
    <MockedProvider
      schema={schema}
      resolvers={{
        Shape: (_, args) => ({
          returnString: `John Doe ${args.id}`,
        }),
      }}
    >
      <Parent shapeId="123" />
    </MockedProvider>
  );
  
  // assert
   expect(response).toMatchObject({
    data: {
      queryShape: {
        __typename: "Shape",
        returnString: "John Doe 123",
        returnInt: expect.toBeNumber(),
      },
    },
  });
```

